### PR TITLE
Fix subplot domains

### DIFF
--- a/dimes/dimes.py
+++ b/dimes/dimes.py
@@ -209,7 +209,7 @@ class TimeSeriesPlot:
 
 def get_subplot_domains(number_of_subplots: int, gap: float = 0.05) -> List[Tuple[float, float]]:
     """Calculate and return the 'Y' domain ranges for a given number of subplots with the specified gap size."""
-    subplot_height = (1.0 - gap) / number_of_subplots
+    subplot_height = (1.0 - gap * (number_of_subplots - 1)) / number_of_subplots
     subplot_domains = []
     for subplot_number in range(number_of_subplots):
         subplot_bottom = subplot_number * (subplot_height + gap)

--- a/dimes/dimes.py
+++ b/dimes/dimes.py
@@ -17,7 +17,6 @@ class TimeSeriesData:
         name: Union[str, None] = None,
         native_units: str = "",
         display_units: Union[str, None] = None,
-        dimension: Union[str, None] = None,
         color: Union[str, None] = None,
         line_type: Union[str, None] = None,
         is_visible: bool = True,
@@ -29,13 +28,6 @@ class TimeSeriesData:
             name
             if name is not None
             else str(self.dimensionality).title().replace("[", "").replace("]", "")
-        )
-        self.dimension = (
-            dimension
-            if dimension is not None
-            else name
-            if name is not None
-            else str(self.dimensionality)
         )
         self.set_display_units(display_units)
         self.color = color

--- a/test/test_dimes.py
+++ b/test/test_dimes.py
@@ -75,14 +75,24 @@ def test_multi_plot():
     )
     # Time series and axis will get name from dimensionality
     plot.add_time_series(
-        TimeSeriesData([x for x in plot.time_values], native_units="ft", display_units="cm"),
-        subplot_number=2
+        TimeSeriesData([x for x in plot.time_values], native_units="ft", display_units="cm")
     )
     # Explicitly name time series and axis
     plot.add_time_series(
         TimeSeriesData([x**3 for x in plot.time_values], name="Number of Apples"),
-        subplot_number=3,
+        subplot_number=2,
         axis_name="Quantity",
+    )
+    # Define dimension for force and set visibility to False
+    plot.add_time_series(
+        TimeSeriesData(
+            [x**4 for x in plot.time_values],
+            name="Force",
+            dimension="[mass] * [length] / [time] ** 2",
+            is_visible=False,
+        ),
+        axis_name="Force",
+        subplot_number=3,
     )
 
     plot.write_html_plot(Path(TESTING_DIRECTORY, "multi_plot.html"))

--- a/test/test_dimes.py
+++ b/test/test_dimes.py
@@ -63,35 +63,39 @@ def test_bad_units():
 def test_multi_plot():
     """Test multiple time series on multiple axes in multiple subplots."""
     plot = TimeSeriesPlot([1, 2, 3, 4, 5])
+    # Time series & axis names explicit, subplot default to 1
     plot.add_time_series(
         TimeSeriesData(
             [x**2 for x in plot.time_values], name="Power", native_units="hp", display_units="W"
         ),
         axis_name="Power or Capacity",
     )
-    # Axis automatically determined by dimensionality
+    # Time series name explicit, axis automatically determined by dimensionality, subplot default to 1
     plot.add_time_series(
-        TimeSeriesData([x * 10 for x in plot.time_values], name="Capacity", native_units="kBtu/h")
+        TimeSeriesData(
+            [x * 10 for x in plot.time_values],
+            name="Capacity",
+            native_units="kBtu/h",
+            is_visible=False,
+        )
     )
-    # Time series and axis will get name from dimensionality
+    # Time series and axis will get name from dimensionality, subplot default to 1, new axis for new dimension on existing subplot
     plot.add_time_series(
         TimeSeriesData([x for x in plot.time_values], native_units="ft", display_units="cm")
     )
-    # Explicitly name time series and axis
+    # Time series & axis names and subplot number are all explicit
     plot.add_time_series(
         TimeSeriesData([x**3 for x in plot.time_values], name="Number of Apples"),
         subplot_number=2,
         axis_name="Quantity",
     )
-    # Define dimension for force and set visibility to False
+    # Time series and subplot number explicit, axis name automatically determined from time series name
     plot.add_time_series(
         TimeSeriesData(
             [x**4 for x in plot.time_values],
             name="Force",
-            dimension="[mass] * [length] / [time] ** 2",
-            is_visible=False,
+            native_units="lbf",
         ),
-        axis_name="Force",
         subplot_number=3,
     )
 

--- a/test/test_dimes.py
+++ b/test/test_dimes.py
@@ -75,12 +75,13 @@ def test_multi_plot():
     )
     # Time series and axis will get name from dimensionality
     plot.add_time_series(
-        TimeSeriesData([x for x in plot.time_values], native_units="ft", display_units="cm")
+        TimeSeriesData([x for x in plot.time_values], native_units="ft", display_units="cm"),
+        subplot_number=2
     )
     # Explicitly name time series and axis
     plot.add_time_series(
         TimeSeriesData([x**3 for x in plot.time_values], name="Number of Apples"),
-        subplot_number=2,
+        subplot_number=3,
         axis_name="Quantity",
     )
 


### PR DESCRIPTION
I ran into an issue when plotting HPWHsim, which has three subplots. When `number_of_subplots` is above 2, `subplot_domains[0]` is outside the allowable range of [0,1].  I adjusted the `subplot_height` calculation to avoid this issue.